### PR TITLE
allow configuring outworld and path when using the binA

### DIFF
--- a/bin/knitwit-postinstall.js
+++ b/bin/knitwit-postinstall.js
@@ -8,9 +8,9 @@ import { KNIT_WIT_CONFIG_FILE } from '../dist/shared/constants.js';
 import yargs from 'yargs/yargs';
 import { hideBin } from 'yargs/helpers';
 
-const getFilePath = () => path.join(process.env.INIT_CWD, KNIT_WIT_CONFIG_FILE);
 const getDirectoryPath = () => process.env.INIT_CWD;
 const getPackageName = () => process.env.npm_package_name;
+const getKnitWitConfigPath = () => path.join(process.env.INIT_CWD, process.env.npm_config_knitwit_source || KNIT_WIT_CONFIG_FILE);
 const getPackagePath = () => process.env.npm_package_config_knitwit_witPath;
 const getDefaultWorld = () => process.env.npm_package_config_knitwit_world;
 
@@ -39,7 +39,7 @@ async function appendEntryIfNotExists(filePath, packageName, packagePath, packag
 }
 
 async function runPostInstallSetup(withPath, world) {
-    let filePath = getFilePath();
+    let filePath = getKnitWitConfigPath();
     let packageName = getPackageName();
     let directoryPath = getDirectoryPath();
     let packagePath = withPath || getPackagePath();

--- a/bin/knitwit.mjs
+++ b/bin/knitwit.mjs
@@ -1,5 +1,22 @@
 #!/usr/bin/env node
 
 import { knitWit } from "../dist/index.js";
+import { hideBin } from 'yargs/helpers';
+import yargs from 'yargs/yargs';
 
-knitWit()
+
+// Parse command line arguments using yargs
+const argv = yargs(hideBin(process.argv))
+    .option('out-dir', {
+        type: 'string',
+        describe: 'Path to combined wit',
+        default: 'generated/wit/combined-wit'
+    })
+    .option('out-world', {
+        type: 'string',
+        describe: 'name of world in combined wit',
+        default: 'combined'
+    })
+    .argv;
+
+knitWit({ outDir: argv['out-dir'], outputWorld: argv['out-world'] });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fermyon/knitwit",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fermyon/knitwit",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
         "@bytecodealliance/preview2-shim": "^0.16.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fermyon/knitwit",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { platform } from "process";
 // Create a require function based on the current working directory
 
 const require = createRequire(path.resolve(process.cwd(), "package.json"));
+const getKnitWitConfigPath = () => path.join(process.env.INIT_CWD!, process.env.npm_config_knitwit_source || KNIT_WIT_CONFIG_FILE);
 
 interface knitWitOptions {
   witPaths?: string[];
@@ -54,14 +55,15 @@ export async function knitWit(
 }
 
 async function attemptParsingConfigFile(): Promise<ParsedConfigFileOutput> {
+  let kniwitConfigPath = getKnitWitConfigPath();
   // If the file does not exist just return an empty response
-  if (!fs.existsSync(KNIT_WIT_CONFIG_FILE)) {
+  if (!fs.existsSync(kniwitConfigPath)) {
     return {
       packages: [], witPaths: [], worlds: []
     }
   }
   try {
-    let contents = fs.readFileSync(KNIT_WIT_CONFIG_FILE, "utf-8");
+    let contents = fs.readFileSync(kniwitConfigPath, "utf-8");
     let data = await knitWitConfigSchema.validate(JSON.parse(contents));
     let packages: string[] = [];
     let witPaths: string[] = [];


### PR DESCRIPTION
Allow configuring where to find the knitwit Config file via `.npmrc`. Also bumps the package version.